### PR TITLE
draft: add keybind to list optional dependencies

### DIFF
--- a/doc/pacseek.1
+++ b/doc/pacseek.1
@@ -68,6 +68,11 @@ Search;
 Install or remove a selected package
 
 .TP
+.B d
+.br
+Show optional dependencies for selected package
+
+.TP
 .BR Tab ", " Ctrl+Up / Down / Left / Right
 Navigate between boxes
 

--- a/internal/pacseek/setup.go
+++ b/internal/pacseek/setup.go
@@ -378,7 +378,7 @@ func (ps *UI) setupKeyBindings() {
 				ps.displayMessage("Minimum number of characters is 2", true)
 				return
 			}
-			ps.displayPackages(ps.lastSearchTerm)
+			ps.displayPackages(ps.lastSearchTerm, false)
 		} else if key == tcell.KeyTAB {
 			ps.app.SetFocus(ps.tablePackages)
 		}
@@ -439,6 +439,11 @@ func (ps *UI) setupKeyBindings() {
 		// ENTER
 		if event.Key() == tcell.KeyEnter {
 			ps.installSelectedPackage()
+			return nil
+		}
+		// show optional dependencies
+		if event.Rune() == 'd' {
+			ps.toggleOptDeps()
 			return nil
 		}
 		// Down / j / k -> noop: WTF? Prevent lock-up with empty list ;) :(

--- a/internal/pacseek/ui.go
+++ b/internal/pacseek/ui.go
@@ -134,7 +134,7 @@ func New(conf *config.Settings, flags args.Flags) (*UI, error) {
 func (ps *UI) Start() error {
 	if ps.flags.SearchTerm != "" {
 		ps.inputSearch.SetText(ps.flags.SearchTerm)
-		ps.displayPackages(ps.flags.SearchTerm)
+		ps.displayPackages(ps.flags.SearchTerm, false)
 	} else {
 		if ps.flags.ShowInstalled {
 			ps.displayInstalled(ps.flags.ShowUpdates)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -62,3 +62,17 @@ func UniqueStrings(strSlices ...[]string) []string {
 
 	return result
 }
+
+// blatant copy of slices.Delete go 1.22 stdlib
+func Delete[S ~[]E, E any](s S, i, j int) S {
+	_ = s[i:j:len(s)] // bounds check
+
+	if i == j {
+		return s
+	}
+
+	oldlen := len(s)
+	s = append(s[:i], s[j:]...)
+	clear(s[len(s):oldlen]) // zero/nil out the obsolete elements, for GC
+	return s
+}


### PR DESCRIPTION
- [ ] needs testing
- [ ] needs update for multiselect to work
- [ ] fix post-install gui quirks

fixes #29 kinda, user is not prompted but can install optdeps manually, with addition of #47 he could select optdeps he wants. Later we could add keybind which would auto-select all optdeps for example `Shift+D`.

I think code is more cleaner than in #47 since we not storing whole InfoRecord just some parts of it thus smaller size, saves memory. Although we add few things to make it work with #47. I will wait for more information on that. I will probably create another branch then and merge multiselect and this together in one pr. 

I was thinking about 2 possible reworks:
- merge together entries from structs to InfoRecord so we won't need new types
- simplify structure from #47 so it doesn't store whole InfoRecord

Demonstration:
https://github.com/user-attachments/assets/c5b98d1d-722c-40e1-9498-54cc096c5ca7