### PR TITLE
draft: regex search

### DIFF
--- a/doc/pacseek.1
+++ b/doc/pacseek.1
@@ -226,13 +226,6 @@ The default is
 .TP
 .BI "\(dqMaxResults\(dq\fR: " number
 The maximum number of results that are displayed in the result list.
-Note that when
-.B SearchMode
-is set to
-.IR StartsWith ,
-it is limited to 100 results from the AUR.
-This is a limitation of an API call that is being used
-(using the official endpoint has an even lower maximum of 20 results).
 
 The default is
 .IR 500 .
@@ -277,18 +270,6 @@ The command that is being run when upgrading packages with
 
 The default is
 .IR yay .
-
-.TP
-.BI "\(dqSearchMode\(dq\fR: " \(dqstring\(dq
-There are two search modes available.
-With the
-.IR Contains
-(default) option, it will show results where the name/description contains the
-search\-term at any position.
-When using the
-.I StartsWith
-option, only those packages are shown where the very beginning of a package
-name/description matched the search\-term.
 
 .TP
 .BI "\(dqSearchBy\(dq\fR: " \(dqstring\(dq

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,6 @@ type Settings struct {
 	InstallCommand          string
 	UninstallCommand        string
 	SysUpgradeCommand       string
-	SearchMode              string
 	SearchBy                string
 	CacheExpiry             int
 	DisableCache            bool
@@ -56,7 +55,6 @@ func Defaults() *Settings {
 		PacmanConfigPath:       "/etc/pacman.conf",
 		InstallCommand:         "yay -S",
 		UninstallCommand:       "yay -Rs",
-		SearchMode:             "Contains",
 		SysUpgradeCommand:      "yay",
 		SearchBy:               "Name",
 		CacheExpiry:            10,
@@ -135,12 +133,6 @@ func Load() (*Settings, error) {
 func (s *Settings) applyUpgradeFixes() {
 	fixApplied := false
 	def := Defaults()
-
-	// search mode: added with 0.1.2
-	if s.SearchMode == "" {
-		s.SearchMode = def.SearchMode
-		fixApplied = true
-	}
 
 	// sysupgrade command: added with 0.2.4
 	if s.SysUpgradeCommand == "" {

--- a/internal/pacseek/draw.go
+++ b/internal/pacseek/draw.go
@@ -18,10 +18,6 @@ import (
 // draws input fields on settings form
 func (ps *UI) drawSettingsFields(disableAur, disableCache, separateAurCommands, pkgbuildInternal, disableFeed bool) {
 	ps.formSettings.Clear(false)
-	mode := 0
-	if ps.conf.SearchMode != "StartsWith" {
-		mode = 1
-	}
 	by := 0
 	if ps.conf.SearchBy != "Name" {
 		by = 1
@@ -97,11 +93,6 @@ func (ps *UI) drawSettingsFields(disableAur, disableCache, separateAurCommands, 
 		ps.formSettings.AddInputField("Cache expiry (m): ", strconv.Itoa(ps.conf.CacheExpiry), 6, nil, sc)
 	}
 	ps.formSettings.AddInputField("Max search results: ", strconv.Itoa(ps.conf.MaxResults), 6, nil, sc).
-		AddDropDown("Search mode: ", []string{"StartsWith", "Contains"}, mode, func(text string, index int) {
-			if text != ps.conf.SearchMode {
-				ps.settingsChanged = true
-			}
-		}).
 		AddDropDown("Search by: ", []string{"Name", "Name & Description"}, by, func(text string, index int) {
 			if text != ps.conf.SearchBy {
 				ps.settingsChanged = true

--- a/internal/pacseek/pacman.go
+++ b/internal/pacseek/pacman.go
@@ -42,7 +42,7 @@ func initPacmanDbs(dbPath, confPath string, repos []string) (*alpm.Handle, error
 }
 
 // searches the pacman databases and returns packages that could be found (starting with "term")
-func searchRepos(h *alpm.Handle, term string, mode string, by string, maxResults int) ([]Package, []Package, error) {
+func searchRepos(h *alpm.Handle, term string, by string, maxResults int) ([]Package, []Package, error) {
 	packages := []Package{}
 	installed := []Package{}
 
@@ -66,13 +66,9 @@ func searchRepos(h *alpm.Handle, term string, mode string, by string, maxResults
 			if counter >= maxResults {
 				break
 			}
-			compFunc := strings.HasPrefix
-			if mode == "Contains" {
-				compFunc = strings.Contains
-			}
 
-			if compFunc(pkg.Name(), term) ||
-				(by == "Name & Description" && compFunc(strings.ToLower(pkg.Description()), term)) {
+			if util.IsMatch(pkg.Name(), term) ||
+				(by == "Name & Description" && util.IsMatch(strings.ToLower(pkg.Description()), term)) {
 				pkg := Package{
 					Name:         pkg.Name(),
 					Source:       db.Name(),
@@ -94,7 +90,7 @@ func searchRepos(h *alpm.Handle, term string, mode string, by string, maxResults
 }
 
 func suggestRepos(h *alpm.Handle, term string) []string {
-	pkgs, _, _ := searchRepos(h, term, "", "", 20)
+	pkgs, _, _ := searchRepos(h, term, "", 20)
 
 	names := []string{}
 	for _, pkg := range pkgs {
@@ -330,7 +326,7 @@ func infoPacman(h *alpm.Handle, computeRequiredBy bool, pkgs ...string) SearchRe
 	return r
 }
 
-// add locally installed satisfiers to pacakge info records
+// add locally installed satisfiers to package info records
 func addLocalSatisfiers(h *alpm.Handle, pkgs ...InfoRecord) {
 	local, err := h.LocalDB()
 

--- a/internal/pacseek/pacseek_test.go
+++ b/internal/pacseek/pacseek_test.go
@@ -45,19 +45,17 @@ func (suite *pacseekTestSuite) TestSearchPacmanDbs() {
 	suite.Nil(err, err)
 
 	// ok
-	p, _, err := searchRepos(h, "glibc", "StartsWith", "Name", 1)
+	p, _, err := searchRepos(h, "glibc", "Name", 1)
 	suite.Nil(err, err)
 	suite.Len(p, 1, "Number of packages != 1")
-	p, _, err = searchRepos(h, "glibc", "StartsWith", "Name & Description", 1)
-	suite.Nil(err, err)
 	suite.Len(p, 1, "Number of packages != 1")
 
 	// nok
-	p, _, err = searchRepos(h, "nonsense_nonsense", "StartsWith", "Name", 1)
+	p, _, err = searchRepos(h, "nonsense_nonsense",  "Name", 1)
 	suite.Nil(err, err)
 	suite.Equal([]Package{}, p, "[]Packages not empty")
 
-	p, _, err = searchRepos(nil, "nonsense_nonsense", "StartsWith", "Name", 1)
+	p, _, err = searchRepos(nil, "nonsense_nonsense", "Name", 1)
 	suite.NotNil(err, err)
 	suite.Equal([]Package{}, p, "[]Packages not empty")
 }
@@ -95,25 +93,7 @@ func (suite *pacseekTestSuite) TestIsInstalled() {
 
 func (suite *pacseekTestSuite) TestSearchAur() {
 	// ok
-	p, err := searchAur("http://server.moson.rocks:10666/rpc", "yay", 5000, "StartsWith", "Name", 20)
-	suite.Nil(err, err)
-	suite.Greater(len(p), 0, "no results for yay")
-	p, err = searchAur("http://server.moson.rocks:10666/rpc", "yay", 5000, "Contains", "Name", 20)
-	suite.Nil(err, err)
-	suite.Greater(len(p), 0, "no results for yay")
-	p, err = searchAur("http://server.moson.rocks:10666/rpc", "yay", 5000, "Contains", "Name & Description", 20)
-	suite.Nil(err, err)
-	suite.Greater(len(p), 0, "no results for yay")
-	p, err = searchAur("http://server.moson.rocks:10666/rpc", "yay", 5000, "StartsWith", "Name & Description", 20)
-	suite.Nil(err, err)
-	suite.Greater(len(p), 0, "no results for yay")
-
-	// nok
-	p, err = searchAur("http://server.moson.rocks:10666/rpcbla", "yay", 5000, "StartsWith", "Name", 20)
-	suite.NotNil(err, err)
-	suite.Equal([]Package{}, p, "[]Packages not empty")
-
-	p, err = searchAur("nonsense", "yay", 5000, "StartsWith", "Name", 20)
+	p, err :=  "Name", 20)
 	suite.NotNil(err, err)
 	suite.Equal([]Package{}, p, "[]Packages not empty")
 }

--- a/internal/pacseek/setup.go
+++ b/internal/pacseek/setup.go
@@ -374,9 +374,6 @@ func (ps *UI) setupKeyBindings() {
 			if len(ps.lastSearchTerm) == 0 {
 				ps.displayInstalled(false)
 				return
-			} else if len(ps.lastSearchTerm) < 2 {
-				ps.displayMessage("Minimum number of characters is 2", true)
-				return
 			}
 			ps.displayPackages(ps.lastSearchTerm)
 		} else if key == tcell.KeyTAB {
@@ -585,8 +582,6 @@ func (ps *UI) saveSettings(defaults bool) {
 		} else if dd, ok := item.(*tview.DropDown); ok {
 			_, opt := dd.GetCurrentOption()
 			switch dd.GetLabel() {
-			case "Search mode: ":
-				ps.conf.SearchMode = opt
 			case "Search by: ":
 				ps.conf.SearchBy = opt
 			case "Color scheme: ":

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"regexp"
 )
 
 // SliceContains checks if a slice contains a certain element
@@ -61,4 +62,13 @@ func UniqueStrings(strSlices ...[]string) []string {
 	}
 
 	return result
+}
+
+// Check if string matches regex
+func IsMatch(str string, expr string) bool {
+	re, err := regexp.Compile(expr)
+	if err != nil || !re.Match([]byte(str)) {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
fixes #44

- [ ] implement cache.go regex search (maybe)
- [x] regex search (partial, see bellow)
- [x] remove minimum search restriction (not quite good **?**)
- [ ] better result ranking (no longer dependent on 3rd party for now)

I choose RE2 standard (perl, python...), but POSIX is also easy to implement, if for some reason someone wants.

For now searching on AUR works as following:
- from search-term are removed special characters - except `.-`
- then on result we perform regex matching

I'm not aware how can I search using regex on api. I was thinking since we're using 3rd party aur pkgmanager, isn't it better to delegate term searching to it? But then not everybody implements regex. And this support is at least something. See for example https://github.com/Jguer/yay/pull/1922.

Searching on alpm is fully working as expected.

Also removed need for config options `SearchMode` since we can use `^` and other regex...